### PR TITLE
remove omitempty from booleans on Oauth2Configuration

### DIFF
--- a/pkg/fusionauth/Domain.go
+++ b/pkg/fusionauth/Domain.go
@@ -1886,10 +1886,10 @@ type OAuth2Configuration struct {
   ClientSecret              string                    `json:"clientSecret,omitempty"`
   DeviceVerificationURL     string                    `json:"deviceVerificationURL,omitempty"`
   EnabledGrants             []GrantType               `json:"enabledGrants,omitempty"`
-  GenerateRefreshTokens     bool                      `json:"generateRefreshTokens,omitempty"`
+  GenerateRefreshTokens     bool                      `json:"generateRefreshTokens"`
   LogoutBehavior            LogoutBehavior            `json:"logoutBehavior,omitempty"`
   LogoutURL                 string                    `json:"logoutURL,omitempty"`
-  RequireClientAuthentication bool                      `json:"requireClientAuthentication,omitempty"`
+  RequireClientAuthentication bool                      `json:"requireClientAuthentication"`
 }
 
 /**


### PR DESCRIPTION
Having omitempty on the booleans of the OAuth2Configuration object means that requireClientAuthentication & generateRefreshTokens can never be set to false in API requests. When either are set to false, they are omitted from the request body and FA defaults them to true.