### PR TITLE
[130] Support for the Message Templates API

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -3,7 +3,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "go-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "go-client", version: "1.23.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/build.savant
+++ b/build.savant
@@ -3,7 +3,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "go-client", version: "1.21.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "go-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/pkg/fusionauth/Client.go
+++ b/pkg/fusionauth/Client.go
@@ -2884,6 +2884,24 @@ func (c *FusionAuthClient) RetrieveMessageTemplate(messageTemplateId string) (*M
     return &resp, err
 }
 
+// RetrieveMessageTemplatePreview
+// Creates a preview of the message template provided in the request, normalized to a given locale.
+//   PreviewMessageTemplateRequest request The request that contains the email template and optionally a locale to render it in.
+func (c *FusionAuthClient) RetrieveMessageTemplatePreview(request PreviewMessageTemplateRequest) (*PreviewMessageTemplateResponse, *Errors, error) {
+    var resp PreviewMessageTemplateResponse
+    var errors Errors
+
+    restClient := c.Start(&resp, &errors)
+    err := restClient.WithUri("/api/message/template/preview").
+      WithJSONBody(request).
+    WithMethod(http.MethodPost).
+    Do()
+    if restClient.ErrorRef == nil {
+      return &resp, nil, err
+    }
+    return &resp, &errors, err
+}
+
 // RetrieveMessageTemplates
 // Retrieves all of the message templates.
 func (c *FusionAuthClient) RetrieveMessageTemplates() (*MessageTemplateResponse, error) {

--- a/pkg/fusionauth/Client.go
+++ b/pkg/fusionauth/Client.go
@@ -542,6 +542,26 @@ func (c *FusionAuthClient) CreateLambda(lambdaId string, request LambdaRequest) 
     return &resp, &errors, err
 }
 
+// CreateMessageTemplate
+// Creates an message template. You can optionally specify an Id for the template, if not provided one will be generated.
+//   string messageTemplateId (Optional) The Id for the template. If not provided a secure random UUID will be generated.
+//   MessageTemplateRequest request The request object that contains all of the information used to create the message template.
+func (c *FusionAuthClient) CreateMessageTemplate(messageTemplateId string, request MessageTemplateRequest) (*MessageTemplateResponse, *Errors, error) {
+    var resp MessageTemplateResponse
+    var errors Errors
+
+    restClient := c.Start(&resp, &errors)
+    err := restClient.WithUri("/api/message/template").
+       WithUriSegment(messageTemplateId).
+      WithJSONBody(request).
+    WithMethod(http.MethodPost).
+    Do()
+    if restClient.ErrorRef == nil {
+      return &resp, nil, err
+    }
+    return &resp, &errors, err
+}
+
 // CreateTenant
 // Creates a tenant. You can optionally specify an Id for the tenant, if not provided one will be generated.
 //   string tenantId (Optional) The Id for the tenant. If not provided a secure random UUID will be generated.
@@ -996,6 +1016,24 @@ func (c *FusionAuthClient) DeleteLambda(lambdaId string) (*BaseHTTPResponse, *Er
     restClient := c.Start(&resp, &errors)
     err := restClient.WithUri("/api/lambda").
        WithUriSegment(lambdaId).
+    WithMethod(http.MethodDelete).
+    Do()
+    if restClient.ErrorRef == nil {
+      return &resp, nil, err
+    }
+    return &resp, &errors, err
+}
+
+// DeleteMessageTemplate
+// Deletes the message template for the given Id.
+//   string messageTemplateId The Id of the message template to delete.
+func (c *FusionAuthClient) DeleteMessageTemplate(messageTemplateId string) (*BaseHTTPResponse, *Errors, error) {
+    var resp BaseHTTPResponse
+    var errors Errors
+
+    restClient := c.Start(&resp, &errors)
+    err := restClient.WithUri("/api/message/template").
+       WithUriSegment(messageTemplateId).
     WithMethod(http.MethodDelete).
     Do()
     if restClient.ErrorRef == nil {
@@ -1872,6 +1910,26 @@ func (c *FusionAuthClient) PatchLambda(lambdaId string, request map[string]inter
     restClient := c.Start(&resp, &errors)
     err := restClient.WithUri("/api/lambda").
        WithUriSegment(lambdaId).
+      WithJSONBody(request).
+    WithMethod(http.MethodPatch).
+    Do()
+    if restClient.ErrorRef == nil {
+      return &resp, nil, err
+    }
+    return &resp, &errors, err
+}
+
+// PatchMessageTemplate
+// Updates, via PATCH, the message template with the given Id.
+//   string messageTemplateId The Id of the message template to update.
+//   MessageTemplateRequest request The request that contains just the new message template information.
+func (c *FusionAuthClient) PatchMessageTemplate(messageTemplateId string, request map[string]interface{}) (*MessageTemplateResponse, *Errors, error) {
+    var resp MessageTemplateResponse
+    var errors Errors
+
+    restClient := c.Start(&resp, &errors)
+    err := restClient.WithUri("/api/message/template").
+       WithUriSegment(messageTemplateId).
       WithJSONBody(request).
     WithMethod(http.MethodPatch).
     Do()
@@ -2810,6 +2868,32 @@ func (c *FusionAuthClient) RetrieveLoginReport(applicationId string, start int64
       return &resp, nil, err
     }
     return &resp, &errors, err
+}
+
+// RetrieveMessageTemplate
+// Retrieves the message template for the given Id. If you don't specify the id, this will return all of the message templates.
+//   string messageTemplateId (Optional) The Id of the message template.
+func (c *FusionAuthClient) RetrieveMessageTemplate(messageTemplateId string) (*MessageTemplateResponse, error) {
+    var resp MessageTemplateResponse
+
+    err := c.Start(&resp, nil).
+             WithUri("/api/message/template").
+       WithUriSegment(messageTemplateId).
+    WithMethod(http.MethodGet).
+    Do()
+    return &resp, err
+}
+
+// RetrieveMessageTemplates
+// Retrieves all of the message templates.
+func (c *FusionAuthClient) RetrieveMessageTemplates() (*MessageTemplateResponse, error) {
+    var resp MessageTemplateResponse
+
+    err := c.Start(&resp, nil).
+             WithUri("/api/message/template").
+    WithMethod(http.MethodGet).
+    Do()
+    return &resp, err
 }
 
 // RetrieveMonthlyActiveReport
@@ -3943,6 +4027,26 @@ func (c *FusionAuthClient) UpdateLambda(lambdaId string, request LambdaRequest) 
     restClient := c.Start(&resp, &errors)
     err := restClient.WithUri("/api/lambda").
        WithUriSegment(lambdaId).
+      WithJSONBody(request).
+    WithMethod(http.MethodPut).
+    Do()
+    if restClient.ErrorRef == nil {
+      return &resp, nil, err
+    }
+    return &resp, &errors, err
+}
+
+// UpdateMessageTemplate
+// Updates the message template with the given Id.
+//   string messageTemplateId The Id of the message template to update.
+//   MessageTemplateRequest request The request that contains all of the new message template information.
+func (c *FusionAuthClient) UpdateMessageTemplate(messageTemplateId string, request MessageTemplateRequest) (*MessageTemplateResponse, *Errors, error) {
+    var resp MessageTemplateResponse
+    var errors Errors
+
+    restClient := c.Start(&resp, &errors)
+    err := restClient.WithUri("/api/message/template").
+       WithUriSegment(messageTemplateId).
       WithJSONBody(request).
     WithMethod(http.MethodPut).
     Do()

--- a/pkg/fusionauth/Domain.go
+++ b/pkg/fusionauth/Domain.go
@@ -1891,10 +1891,6 @@ type Lambda struct {
   Type                             LambdaType                         `json:"type,omitempty"`
 }
 
-type ProviderLambdaConfiguration struct {
-  ReconcileId                      string                             `json:"reconcileId,omitempty"`
-}
-
 type LambdaConfiguration struct {
   AccessTokenPopulateId            string                             `json:"accessTokenPopulateId,omitempty"`
   IdTokenPopulateId                string                             `json:"idTokenPopulateId,omitempty"`
@@ -1902,6 +1898,10 @@ type LambdaConfiguration struct {
 }
 
 type ConnectorLambdaConfiguration struct {
+  ReconcileId                      string                             `json:"reconcileId,omitempty"`
+}
+
+type ProviderLambdaConfiguration struct {
   ReconcileId                      string                             `json:"reconcileId,omitempty"`
 }
 

--- a/pkg/fusionauth/Domain.go
+++ b/pkg/fusionauth/Domain.go
@@ -2170,6 +2170,15 @@ func (b *MemberResponse) SetStatus(status int) {
 }
 
 /**
+ * An incredible simplified view of a message
+ *
+ * @author Michael Sleevi
+ */
+type Message struct {
+  Text                             string                             `json:"text,omitempty"`
+}
+
+/**
  * Stores an message template used to distribute messages;
  *
  * @author Michael Sleevi
@@ -2511,6 +2520,23 @@ type PendingResponse struct {
   Users                            []User                             `json:"users,omitempty"`
 }
 func (b *PendingResponse) SetStatus(status int) {
+  b.StatusCode = status
+}
+
+/**
+ * @author Michael Sleevi
+ */
+type PreviewMessageTemplateRequest struct {
+  Locale                           string                             `json:"locale,omitempty"`
+  MessageTemplate                  MessageTemplate                    `json:"messageTemplate,omitempty"`
+}
+
+type PreviewMessageTemplateResponse struct {
+  BaseHTTPResponse
+  Errors                           Errors                             `json:"errors,omitempty"`
+  Message                          Message                            `json:"message,omitempty"`
+}
+func (b *PreviewMessageTemplateResponse) SetStatus(status int) {
   b.StatusCode = status
 }
 

--- a/pkg/fusionauth/Domain.go
+++ b/pkg/fusionauth/Domain.go
@@ -2169,6 +2169,38 @@ func (b *MemberResponse) SetStatus(status int) {
   b.StatusCode = status
 }
 
+/**
+ * Stores an message template used to distribute messages;
+ *
+ * @author Michael Sleevi
+ */
+type MessageTemplate struct {
+  DefaultTemplate                  string                             `json:"defaultTemplate,omitempty"`
+  Id                               string                             `json:"id,omitempty"`
+  InsertInstant                    int64                              `json:"insertInstant,omitempty"`
+  LastUpdateInstant                int64                              `json:"lastUpdateInstant,omitempty"`
+  LocalizedTemplates               map[string]string                  `json:"localizedTemplates,omitempty"`
+  Name                             string                             `json:"name,omitempty"`
+}
+
+/**
+ * A Message Template Request to the API
+ *
+ * @author Michael Sleevi
+ */
+type MessageTemplateRequest struct {
+  MessageTemplate                  MessageTemplate                    `json:"messageTemplate,omitempty"`
+}
+
+type MessageTemplateResponse struct {
+  BaseHTTPResponse
+  MessageTemplate                  MessageTemplate                    `json:"messageTemplate,omitempty"`
+  MessageTemplates                 []MessageTemplate                  `json:"messageTemplates,omitempty"`
+}
+func (b *MessageTemplateResponse) SetStatus(status int) {
+  b.StatusCode = status
+}
+
 type MetaData struct {
   Device                           DeviceInfo                         `json:"device,omitempty"`
   Scopes                           []string                           `json:"scopes,omitempty"`

--- a/pkg/fusionauth/Domain.go
+++ b/pkg/fusionauth/Domain.go
@@ -1891,6 +1891,10 @@ type Lambda struct {
   Type                             LambdaType                         `json:"type,omitempty"`
 }
 
+type ProviderLambdaConfiguration struct {
+  ReconcileId                      string                             `json:"reconcileId,omitempty"`
+}
+
 type LambdaConfiguration struct {
   AccessTokenPopulateId            string                             `json:"accessTokenPopulateId,omitempty"`
   IdTokenPopulateId                string                             `json:"idTokenPopulateId,omitempty"`
@@ -1898,10 +1902,6 @@ type LambdaConfiguration struct {
 }
 
 type ConnectorLambdaConfiguration struct {
-  ReconcileId                      string                             `json:"reconcileId,omitempty"`
-}
-
-type ProviderLambdaConfiguration struct {
   ReconcileId                      string                             `json:"reconcileId,omitempty"`
 }
 


### PR DESCRIPTION
Related Issues
----

* [130](https://github.com/FusionAuth/fusionauth-internal-issues/issues/130)

Background
-----

This PR incorporates the client changes for the support of enhanced MFA functionality.

Implementation Details
-----

* Adds new Message Template methods for interacting with the upcoming APIs, namely:
  * Supports PUT /api/message/template/{id}
  * Supports GET /api/message/template/{id}
  * Supports GET /api/message/template
  * Supports POST /api/message/template
  * Supports DELETE /api/message/template
  * Supports PATCH /api/message/template/{id}
  * Supports POST /api/message/template/preview
* Adds new Domain objects and responses for the upcoming APIs, namely:
  * `io.fusionauth.domain.api.MessageTemplateRequest`
  * `io.fusionauth.domain.api.MessageTemplateResponse`
  * `io.fusionauth.domain.api.PreviewMessageTemplateRequest`
  * `io.fusionauth.domain.api.PreviewMessageTemplateResponse`
  * `io.fusionauth.domain.message.MessageTemplate`
  * `io.fusionauth.domain.message.Message`