### PR TITLE
Application registration for an existing user fails

### DIFF
--- a/pkg/fusionauth/Domain.go
+++ b/pkg/fusionauth/Domain.go
@@ -4124,7 +4124,7 @@ type RegistrationRequest struct {
 	SendSetPasswordEmail         bool             `json:"sendSetPasswordEmail"`
 	SkipRegistrationVerification bool             `json:"skipRegistrationVerification"`
 	SkipVerification             bool             `json:"skipVerification"`
-	User                         User             `json:"user,omitempty"`
+	User                         *User            `json:"user,omitempty"`
 }
 
 /**


### PR DESCRIPTION
Application registration for an existing user fails due to the non-nillable user field in the RegistrationRequest struct. Change User type property to a pointer