### PR TITLE
Add tenant id header

### DIFF
--- a/pkg/fusionauth/Client.go
+++ b/pkg/fusionauth/Client.go
@@ -293,7 +293,7 @@ func (c *FusionAuthClient) ChangePasswordByIdentity(request ChangePasswordReques
 
 	restClient := c.Start(&resp, &errors)
 	if request.TenantId != "" {
-		restClient.WithHeader("X-FusionAuth-TenantId", c.TenantId)
+		restClient.WithHeader("X-FusionAuth-TenantId", request.TenantId)
 	}
 	err := restClient.WithUri("/api/user/change-password").
 		WithJSONBody(request).

--- a/pkg/fusionauth/Client.go
+++ b/pkg/fusionauth/Client.go
@@ -292,6 +292,9 @@ func (c *FusionAuthClient) ChangePasswordByIdentity(request ChangePasswordReques
 	var errors Errors
 
 	restClient := c.Start(&resp, &errors)
+	if request.TenantId != "" {
+		restClient.WithHeader("X-FusionAuth-TenantId", c.TenantId)
+	}
 	err := restClient.WithUri("/api/user/change-password").
 		WithJSONBody(request).
 		WithMethod(http.MethodPost).

--- a/pkg/fusionauth/Domain.go
+++ b/pkg/fusionauth/Domain.go
@@ -704,6 +704,7 @@ type ChangePasswordRequest struct {
 	RefreshToken     string `json:"refreshToken,omitempty"`
 	TrustChallenge   string `json:"trustChallenge,omitempty"`
 	TrustToken       string `json:"trustToken,omitempty"`
+	TenantId         string `json:"tenantId,omitempty"`
 }
 
 /**


### PR DESCRIPTION
The API doesn't work without the tenant ID if multiple tenants exist. 