### PR TITLE
Changes the return type of the client method RetreiveUserAction

### DIFF
--- a/pkg/fusionauth/Client.go
+++ b/pkg/fusionauth/Client.go
@@ -4434,8 +4434,8 @@ func (c *FusionAuthClient) RetrieveUserConsents(userId string) (*UserConsentResp
 // RetrieveUserInfoFromAccessToken
 // Call the UserInfo endpoint to retrieve User Claims from the access token issued by FusionAuth.
 //   string encodedJWT The encoded JWT (access token).
-func (c *FusionAuthClient) RetrieveUserInfoFromAccessToken(encodedJWT string) (*UserinfoResponse, *OAuthError, error) {
-	var resp UserinfoResponse
+func (c *FusionAuthClient) RetrieveUserInfoFromAccessToken(encodedJWT string) (*UserResponse, *OAuthError, error) {
+	var resp UserResponse
 	var errors OAuthError
 
 	restClient := c.StartAnonymous(&resp, &errors)


### PR DESCRIPTION
I noticed that when I tried to import the package into my go project I was getting the following error:
```

# github.com/FusionAuth/go-client/pkg/fusionauth
../../../go/pkg/mod/github.com/!fusion!auth/go-client@v0.0.0-20230509031230-4b4943022898/pkg/fusionauth/Client.go:4437:81: undefined: UserinfoResponse
../../../go/pkg/mod/github.com/!fusion!auth/go-client@v0.0.0-20230509031230-4b4943022898/pkg/fusionauth/Client.go:4438:11: undefined: UserinfoResponse
```

So, I pulled down the source code for the project and noticed that the client method RetrieveUserInfoFromAccessToken was creating an error in compiling and testing.

Specifically, the method was trying to return a type called UserInfoResponse, but that struct does not exist in the client or domain files. So, I pulled the code history and noticed that the method previously returned a pointer to a UserResponse struct. I changed the return type to the UserResponse struct, tested the code out and it seemed to work.

Fixes #72 