### PR TITLE
Added OauthRefreshTokenExpirationPolicy type

### DIFF
--- a/pkg/fusionauth/Domain.go
+++ b/pkg/fusionauth/Domain.go
@@ -7805,3 +7805,19 @@ func (b *EventLogResponse) SetStatus(status int) {
 type TenantRegistrationConfiguration struct {
 	BlockedDomains []string `json:"blockedDomains,omitempty"`
 }
+
+/**
+ * Controls the policy for refresh token expiration
+ * @author Maksym Cierżniak
+ */
+type OauthRefreshTokenExpirationPolicy string
+
+func (e OauthRefreshTokenExpirationPolicy) String() string {
+	return string(e)
+}
+
+const (
+	OauthRefreshTokenExpirationPolicy_Fixed                            RefreshTokenExpirationPolicy = "Fixed"
+	OauthRefreshTokenExpirationPolicy_SlidingWindow                    RefreshTokenExpirationPolicy = "SlidingWindow"
+	OauthRefreshTokenExpirationPolicy_SlidingWindowWithMaximumLifetime RefreshTokenExpirationPolicy = "SlidingWindowWithMaximumLifetime"
+)


### PR DESCRIPTION
This PR adds new enum for `application.jwtConfiguration.refreshTokenExpirationPolicy` (https://fusionauth.io/docs/apis/applications#update-an-application) which can be then used in Terraform provider
https://github.com/FusionAuth/terraform-provider-fusionauth/issues/272